### PR TITLE
修改失误写错导致逻辑错误的字段

### DIFF
--- a/src/views/manage/role/role_args.ts
+++ b/src/views/manage/role/role_args.ts
@@ -110,7 +110,7 @@ const rule: Rule[] = [
     },
     {
         name: 'DDLAllowColumnType',
-        desc: '允许字段进行类型转换(不同字段之间的转换或长度从长变短。如:int -> bigint,int(50) -> int(20))',
+        desc: '允许字段进行类型转换(不同字段之间的转换或长度从长变短。如:bigint -> int,int(50) -> int(20))',
         type: 'DDL',
         tp: 0
     },


### PR DESCRIPTION
原来：允许字段进行类型转换(不同字段之间的转换或长度从长变短。如:int -> bigint,int(50) -> int(20)) 关闭就是限制  不同类型不能转换 和  长度不能从长变短
而后面的 如:int -> bigint 给不熟悉的使用人带来了困惑，现在改正！